### PR TITLE
CIを整備して、古いRubyバージョンのサポートを落とした

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types:
       - opened
@@ -20,41 +20,22 @@ jobs:
       fail-fast: false
 
       matrix:
-        ruby:
-          - ruby:2.2
-          - ruby:2.3
-          - ruby:2.4
-          - ruby:2.5
-          - ruby:2.6
-          - ruby:2.7
-          - ruby:3.0
-          - rubylang/ruby:master-nightly-bionic
+        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', 'head']
         include:
-          - ruby: rubylang/ruby:master-nightly-bionic
-            allow_failures: "true"
+          - ruby-version: 'head'
+            allow_failures: 'true'
 
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Cache vendor/bundle
-        uses: actions/cache@v1
-        id: cache_gem
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          path: vendor/bundle
-          key: v1-gem-${{ runner.os }}-${{ matrix.ruby }}-${{ github.sha }}
-          restore-keys: |
-            v1-gem-${{ runner.os }}-${{ matrix.ruby }}-
-        continue-on-error: ${{ matrix.allow_failures == 'true' }}
-
-      - name: bundle update
-        run: |
-          set -xe
-          bundle config path vendor/bundle
-          bundle update --jobs $(nproc) --retry 3
-        continue-on-error: ${{ matrix.allow_failures == 'true' }}
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
 
       - name: Run test
         run: |
           set -xe
           bundle exec rake
         continue-on-error: ${{ matrix.allow_failures == 'true' }}
+

--- a/README.md
+++ b/README.md
@@ -30,14 +30,15 @@ takarabakoをインストールすると
 ```
 ## Supported versions
 
-- 1.9.3
-- 2.0.0
-- 2.1.x
-- 2.2.x
 - 2.3.x
 - 2.4.x
 - 2.5.x
 - 2.6.x
+- 2.7.x
+- 3.0.x
+- 3.1.x
+- 3.2.x
+
 
 ## Installation
 


### PR DESCRIPTION
Ruby2.2以下ではbundler2系をインストールできずにbundlerのinstallで失敗する。流石にもうRuby2.2以下を使っている人はいないと思われるので、この機会にサポートを落とすことにした。
